### PR TITLE
necessary changes so that 'python setup.py install' works under python 3.6

### DIFF
--- a/minerva/deconvolution/utils.py
+++ b/minerva/deconvolution/utils.py
@@ -2,7 +2,7 @@ import sys
 import argparse as ap
 import numpy as np
 import math
-from gimmebio.kmers import *
+from ..gimmebio.kmers import *
 
 
 ################################################################################

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     description="Toolsets for deconvolving and clustering barcoded short reads",
     long_description=open('README.rst').read(),
 
-    packages=['minerva'],
+    packages=setuptools.find_packages(),
     package_dir={'minerva': 'minerva'},
     
     ext_modules = [setuptools.Extension("cseqs", ["cext_minerva/_cseqs.c","cext_minerva/cseqs.c"])],


### PR DESCRIPTION
I had to do those changes, otherwise minerva wouldn't install properly on my system (python 3.6)